### PR TITLE
Update Audio System to Allow for Primed Audios

### DIFF
--- a/Assets/Scripts/Sound/Player/AudioPlayer.cs
+++ b/Assets/Scripts/Sound/Player/AudioPlayer.cs
@@ -44,6 +44,10 @@ namespace Sound.Player
         private void Start()
         {
             _source = GetComponent<AudioSource>();
+            if (Container != null)
+            {
+                Container.Prime();
+            }
         }
 
         public void Play(bool force, bool customContainer = false) 

--- a/Assets/Scripts/Sound/Source/Internal/ResourceClip.cs
+++ b/Assets/Scripts/Sound/Source/Internal/ResourceClip.cs
@@ -49,6 +49,10 @@ namespace Sound.Source.Internal
             };
         }
 
+        public void Prime()
+        {
+            Start();
+        }
         public void Start() 
         {
             LoadAudio();

--- a/Assets/Scripts/Sound/Source/Internal/ResourceList.cs
+++ b/Assets/Scripts/Sound/Source/Internal/ResourceList.cs
@@ -63,7 +63,10 @@ namespace Sound.Source.Internal
                     Loop = new ValueRange(1)
                 });
         }
-
+        public void Prime() 
+        {
+            Start();
+        }
         public void Start() 
         {
             LoadAudio();

--- a/Assets/Scripts/Sound/Source/Internal/SoundClip.cs
+++ b/Assets/Scripts/Sound/Source/Internal/SoundClip.cs
@@ -32,6 +32,8 @@ namespace Sound.Source.Internal
         {
         }
 
+        public void Prime() { }
+
         public ISound Clone() 
         {
             SoundClip clone = new SoundClip();

--- a/Assets/Scripts/Sound/Source/SilentSource.cs
+++ b/Assets/Scripts/Sound/Source/SilentSource.cs
@@ -25,6 +25,10 @@ namespace Sound.Source
 
         public SilentSource() { }
         public void Start() { }
+        public void Prime()
+        {
+            Start();
+        }
         public ISound Clone() 
         {
             SilentSource clone = new SilentSource();

--- a/Assets/Scripts/Sound/Structure/Container.cs
+++ b/Assets/Scripts/Sound/Structure/Container.cs
@@ -55,6 +55,14 @@ namespace Sound.Structure
 
         protected abstract List<ISound> GetContainerInstance();
 
+        public void Prime() 
+        {
+            foreach (var container in _containers) 
+            {
+                container.Prime();
+            }
+        }
+
         public virtual void Start()
         {
             _onLoop = 1;

--- a/Assets/Scripts/Sound/Structure/ISound.cs
+++ b/Assets/Scripts/Sound/Structure/ISound.cs
@@ -61,5 +61,10 @@ namespace Sound.Structure
         /// </summary>
         /// <returns>A copy of the original ISound</returns>
         public ISound Clone();
+
+        /// <summary>
+        /// Loads all of the sound clips into unity at once.
+        /// </summary>
+        public void Prime();
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1.68
+  bundleVersion: 0.1.69
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}


### PR DESCRIPTION
The audio will now load in before the moment it's played. If using a AudioPlayer, the container item is primed. Is running a one-shot, then you must use ISound#Prime() beforehand to make sure the audio is loaded. (it will load on play if it's not loaded already, but that may cause lag)